### PR TITLE
Recover gracefully from unknown origin/HEAD

### DIFF
--- a/lib/branch.sh
+++ b/lib/branch.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
-FILES="$(git diff $(git merge-base origin/HEAD HEAD).. --name-only)"
+FILES="$(git diff $(git merge-base origin/HEAD HEAD 2> /dev/null || (git remote set-head origin -a > /dev/null && git merge-base origin/HEAD HEAD)).. --name-only)"
 if [ -n "$FILES" ]; then
   echo "$FILES" | sort -u | xargs find 2> /dev/null
 fi


### PR DESCRIPTION
Sometimes you don't have origin/HEAD.  This recovers gracefully from that state.  To see it in action, `rm .git/refs/remotes/origin/HEAD`

This fixes #4