### PR TITLE
Avoid truncation in branch_modified.sh when files have been deleted

### DIFF
--- a/lib/branch.sh
+++ b/lib/branch.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
 FILES="$(git diff $(git merge-base origin/HEAD HEAD 2> /dev/null || (git remote set-head origin -a > /dev/null && git merge-base origin/HEAD HEAD)).. --name-only)"
 if [ -n "$FILES" ]; then
-  echo "$FILES" | sort -u | xargs find 2> /dev/null
+  echo "$FILES" | sort -u | xargs find 2> /dev/null || true
 fi

--- a/lib/modified.sh
+++ b/lib/modified.sh
@@ -4,6 +4,6 @@ if [ -e .git/MERGE_HEAD ] || [ -d .git/rebase-merge ] || [ -d .git/rebase-apply 
 else
   FILES="$(git status --porcelain -z --untracked-files=all | tr '\0' '\n')"
   if [ -n "$FILES" ]; then
-    echo "$FILES" | cut -c 4- | tr '\n' '\0' | xargs -0 find 2> /dev/null
+    echo "$FILES" | cut -c 4- | tr '\n' '\0' | xargs -0 find 2> /dev/null || true
   fi
 fi


### PR DESCRIPTION
The `xargs find` exits with error if any files were deleted, which can cause the results in branch_modified.sh to be truncated (branch.sh runs but modified.sh doesn't).